### PR TITLE
Feature/conversion/types

### DIFF
--- a/src/test/java/com/excelninja/infrastructure/converter/DefaultConverterTest.java
+++ b/src/test/java/com/excelninja/infrastructure/converter/DefaultConverterTest.java
@@ -1,0 +1,86 @@
+package com.excelninja.infrastructure.converter;
+
+import com.excelninja.domain.exception.DocumentConversionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("BigDecimal과 LocalDateTime 지원 테스트")
+class DefaultConverterTest {
+
+    private final DefaultConverter converter = new DefaultConverter();
+
+    @Test
+    @DisplayName("BigDecimal 변환 테스트")
+    void convertToBigDecimal() {
+        assertThat(converter.convert("123.456", BigDecimal.class)).isEqualTo(new BigDecimal("123.456"));
+        assertThat(converter.convert("999999999999999999.999999999", BigDecimal.class)).isEqualTo(new BigDecimal("999999999999999999.999999999"));
+        assertThat(converter.convert(123.45, BigDecimal.class)).isEqualTo(BigDecimal.valueOf(123.45));
+        assertThat(converter.convert(100, BigDecimal.class)).isEqualTo(BigDecimal.valueOf(100.0));
+        assertThat(converter.convert(123L, BigDecimal.class)).isEqualTo(BigDecimal.valueOf(123.0));
+
+        BigDecimal originalBigDecimal = new BigDecimal("999.99");
+        assertThat(converter.convert(originalBigDecimal, BigDecimal.class)).isSameAs(originalBigDecimal);
+
+        assertThatThrownBy(() -> converter.convert("invalid_number", BigDecimal.class))
+                .isInstanceOf(DocumentConversionException.class)
+                .hasMessageContaining("Cannot parse 'invalid_number' as BigDecimal");
+    }
+
+    @Test
+    @DisplayName("LocalDate 변환 테스트")
+    void convertToLocalDate() {
+        LocalDate lastChristmas = LocalDate.of(2024, 12, 25);
+        assertThat(converter.convert("2024-12-25", LocalDate.class)).isEqualTo(lastChristmas);
+        assertThat(converter.convert("25/12/2024", LocalDate.class)).isEqualTo(lastChristmas);
+        assertThat(converter.convert("12/25/2024", LocalDate.class)).isEqualTo(lastChristmas);
+        assertThat(converter.convert("2024/12/25", LocalDate.class)).isEqualTo(lastChristmas);
+        assertThat(converter.convert("25-12-2024", LocalDate.class)).isEqualTo(lastChristmas);
+
+        Date date = new Date(124, 11, 25);
+        LocalDate convertedDate = (LocalDate) converter.convert(date, LocalDate.class);
+        assertThat(convertedDate.getYear()).isEqualTo(2024);
+        assertThat(convertedDate.getMonthValue()).isEqualTo(12);
+        assertThat(convertedDate.getDayOfMonth()).isEqualTo(25);
+
+        LocalDateTime dateTime = LocalDateTime.of(2024, 12, 25, 14, 30, 0);
+        assertThat(converter.convert(dateTime, LocalDate.class)).isEqualTo(lastChristmas);
+
+        assertThatThrownBy(() -> converter.convert("invalid_date", LocalDate.class))
+                .isInstanceOf(DocumentConversionException.class)
+                .hasMessageContaining("Cannot parse date string 'invalid_date'");
+    }
+
+    @Test
+    @DisplayName("LocalDateTime 변환 테스트")
+    void convertToLocalDateTime() {
+        LocalDateTime lastChristmasTwoThirty = LocalDateTime.of(2024, 12, 25, 14, 30, 0);
+        assertThat(converter.convert("2024-12-25T14:30:00", LocalDateTime.class)).isEqualTo(lastChristmasTwoThirty);
+        assertThat(converter.convert("2024-12-25 14:30:00", LocalDateTime.class)).isEqualTo(lastChristmasTwoThirty);
+        assertThat(converter.convert("2024-12-25 14:30", LocalDateTime.class)).isEqualTo(lastChristmasTwoThirty);
+        assertThat(converter.convert("25/12/2024 14:30:00", LocalDateTime.class)).isEqualTo(lastChristmasTwoThirty);
+        assertThat(converter.convert("12/25/2024 14:30:00", LocalDateTime.class)).isEqualTo(lastChristmasTwoThirty);
+
+        Date date = new Date(124, 11, 25, 14, 30, 0);
+        LocalDateTime convertedDateTime = (LocalDateTime) converter.convert(date, LocalDateTime.class);
+        assertThat(convertedDateTime.getYear()).isEqualTo(2024);
+        assertThat(convertedDateTime.getMonthValue()).isEqualTo(12);
+        assertThat(convertedDateTime.getDayOfMonth()).isEqualTo(25);
+        assertThat(convertedDateTime.getHour()).isEqualTo(14);
+        assertThat(convertedDateTime.getMinute()).isEqualTo(30);
+
+        LocalDate date2 = LocalDate.of(2024, 12, 25);
+        assertThat(converter.convert(date2, LocalDateTime.class)).isEqualTo(LocalDateTime.of(2024, 12, 25, 0, 0, 0));
+
+        assertThatThrownBy(() -> converter.convert("invalid_datetime", LocalDateTime.class))
+                .isInstanceOf(DocumentConversionException.class)
+                .hasMessageContaining("Cannot parse datetime string 'invalid_datetime'");
+    }
+}


### PR DESCRIPTION
## 📋 Description
Enhanced DefaultConverter to support BigDecimal and LocalDateTime types for more precise financial calculations and comprehensive date/time handling in Excel processing.

## 🔄 Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## 🐛 Bug Fixes
- 

## ✨ New Features
- Added BigDecimal support for precise decimal calculations in financial applications
- Added LocalDateTime support for comprehensive date and time handling
- Enhanced Date to LocalDate/LocalDateTime conversion from Excel Date cells
- Support for multiple datetime string formats (ISO, slash, dash separated)
- Improved type conversion error messages with detailed format information

## 💥 Breaking Changes
- 

## 📝 Documentation
- Added comprehensive JavaDoc comments for new conversion methods
- Updated README examples to showcase BigDecimal and LocalDateTime usage
- Added DTO examples demonstrating financial and employee data handling

## 🧪 Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests pass

## 🔗 Related Issues
- Closes #
- Fixes #
- Resolves #

## 📸 Screenshots (if applicable)
<!-- Add screenshots here -->

## ⚠️ Notes for Reviewers
- Focus on the precision handling in BigDecimal conversion methods
- Review the datetime format parsing logic for edge cases
- Check error message clarity for failed conversions
- Verify backward compatibility with existing number and date conversions

## 🚀 Deployment Notes
- No breaking changes - fully backward compatible
- New types will be automatically supported for existing @ExcelReadColumn/@ExcelWriteColumn annotations
- Performance impact is minimal as conversions are only triggered when target types match

---

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published